### PR TITLE
Replaced the 2012 version of referenced TDS assembly with 2013

### DIFF
--- a/Constellation.Sitecore.Items.Tds.csproj
+++ b/Constellation.Sitecore.Items.Tds.csproj
@@ -30,8 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="HedgehogDevelopment.SitecoreProject.VSIP2012">
-      <HintPath>..\..\..\Program Files (x86)\Hedgehog Development\Team Development for Sitecore (VS2012)\HedgehogDevelopment.SitecoreProject.VSIP2012.dll</HintPath>
+    <Reference Include="HedgehogDevelopment.SitecoreProject.VSIP2013">
+      <HintPath>..\..\Program Files (x86)\Hedgehog Development\Team Development for Sitecore (VS2013)\HedgehogDevelopment.SitecoreProject.VSIP2013.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
This makes this assembly only compatible to visual studio 2013,
